### PR TITLE
update: add proper alt text to images

### DIFF
--- a/opsimate-docs/docs/alerts/alert-management.md
+++ b/opsimate-docs/docs/alerts/alert-management.md
@@ -6,9 +6,8 @@ sidebar_position: 2
 
 The Alert Management page provides a centralized view of all alerts across your services and integrations.
 
-
 <div style={{textAlign: 'center', margin: '30px 0'}}>
-  <img src="/img/alertpage.png" alt="OpsiMate Alerts Page" style={{width: '700px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/alertpage.png" alt="Screenshot of OpsiMate Alerts page" style={{width: '700px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>OpsiMate alerts dashboard showing real-time notifications and alert management</p>
 </div>
 
@@ -22,7 +21,9 @@ Access the Alert Management page to:
 ## Alert Dashboard Features
 
 ### All Active Alerts
+
 View currently active alerts across all your services:
+
 - Real-time status updates from integration providers
 - Severity levels (Critical, Warning, Info)
 - Associated services and tags
@@ -31,6 +32,7 @@ View currently active alerts across all your services:
 ## Integration Sources
 
 Alerts are aggregated from all configured integrations:
+
 - Grafana alert rules
 
 Each alert shows its source integration for easy traceability back to the original monitoring system.

--- a/opsimate-docs/docs/dashboards/overview.md
+++ b/opsimate-docs/docs/dashboards/overview.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 The main interface for monitoring and controlling your services.
 
 <div style={{textAlign: 'center', margin: '30px 0'}}>
-  <img src="/img/dashboard-fullview.png" alt="OpsiMate Dashboard" style={{width: '800px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/dashboard-fullview.png" alt="Screenshot of OpsiMate dashboard full view" style={{width: '800px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>OpsiMate main dashboard showing service overview and controls</p>
 </div>
 
@@ -42,5 +42,6 @@ Control services directly from the dashboard interface.
 Filter and organize services for better visibility.
 
 ### Search Functionality
+
 - **Quick Search**: Find services by name or description
 - **Saved Searches**: Store frequently used filter combinations

--- a/opsimate-docs/docs/dashboards/service-menu.md
+++ b/opsimate-docs/docs/dashboards/service-menu.md
@@ -11,7 +11,7 @@ Access service-specific options and controls through the right-side menu.
 Click on any service in the dashboard to open the service-specific menu panel.
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/service-sidebar.png" alt="Service Menu Sidebar" style={{width: '400px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/service-sidebar.png" alt="Screenshot of service menu sidebar" style={{width: '400px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>Service menu sidebar with detailed controls and information</p>
 </div>
 
@@ -29,30 +29,35 @@ Click on any service in the dashboard to open the service-specific menu panel.
 ## Menu Options
 
 ### Service Control
+
 - **Start Service**: Activate inactive services
 - **Stop Service**: Gracefully stop running services
 - **Restart Service**: Restart services to resolve issues
 - **Force Stop**: Emergency service termination
 
 ### Monitoring & Alerts
+
 - **Configure Alerts**: Set up service-specific notifications
 - **View Metrics**: Access detailed performance data
 - **Health Checks**: Configure and view service health status
 - **Threshold Settings**: Set resource usage alerts
 
 ### Logs & Diagnostics
+
 - **View Logs**: Access real-time service logs
 - **Download Logs**: Export log files for analysis
 - **Log Filtering**: Search and filter log entries
 - **Error Analysis**: Identify and analyze service errors
 
 ### Service Configuration
+
 - **Edit Settings**: Modify service configuration
 - **Environment Variables**: Manage service environment
 - **Resource Limits**: Set CPU and memory constraints
 - **Dependency Management**: Configure service dependencies
 
 ### Tags & Organization
+
 - **Add Tags**: Label services for better organization
 - **Edit Description**: Update service descriptions
 - **Group Assignment**: Assign services to logical groups
@@ -63,16 +68,19 @@ Click on any service in the dashboard to open the service-specific menu panel.
 Menu options adapt based on service type and current status.
 
 ### For Running Services
+
 - Stop and restart options available
 - Real-time metrics and logs accessible
 - Performance monitoring active
 
 ### For Stopped Services
+
 - Start option prominently displayed
 - Configuration editing enabled
 - Historical data available
 
 ### Service Type Specific
+
 - **Systemd Services**: Systemctl command options
 - **Docker Containers**: Container management commands
 - **Kubernetes Pods**: Kubectl operations and namespace management

--- a/opsimate-docs/docs/getting-started/deploy.md
+++ b/opsimate-docs/docs/getting-started/deploy.md
@@ -56,7 +56,7 @@ curl http://localhost:8080/health
 
 When you first access OpsiMate at `http://localhost:8080`, you'll be prompted to create your first admin user:
 
-<img src="/img/first-login.png" alt="First Login Screen" style={{width: '400px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+<img src="/img/first-login.png" alt="Screenshot of first login screen" style={{width: '400px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
 
 Simply fill in your email, full name, and password to create the initial admin account. This user will have full administrative privileges to configure providers, manage services, and access all OpsiMate features.
 

--- a/opsimate-docs/docs/integrations/overview.md
+++ b/opsimate-docs/docs/integrations/overview.md
@@ -46,9 +46,10 @@ Cloud monitoring and analytics platform for infrastructure, applications, and lo
 4. Follow the setup instructions
 
 <div class="image-container">
-  <img src="/img/adding-grafana-integration.png" alt="Grafana Integration Setup" />
+  <img src="/img/adding-grafana-integration.png" alt="Screenshot of Grafana integration setup" />
   <p>Setting up Grafana integration in OpsiMate</p>
 </div>
+
 
 Select an integration to learn how to set it up:
 

--- a/opsimate-docs/docs/providers-services/overview.md
+++ b/opsimate-docs/docs/providers-services/overview.md
@@ -33,7 +33,7 @@ Understanding the relationship between providers and services is key to effectiv
 </div>
 
 <div style={{textAlign: 'center', margin: '30px 0'}}>
-  <img src="/img/provider-overview.png" alt="Provider Overview Dashboard" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/provider-overview.png" alt="Screenshot of provider overview dashboard" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>OpsiMate provider overview showing connected infrastructure</p>
 </div>
 
@@ -58,13 +58,12 @@ Understanding the relationship between providers and services is key to effectiv
   </div>
 </div>
 
-
 ## Getting Started
 
 Ready to set up your infrastructure monitoring?
 
 1. **[Add Providers](providers/add-provider)** - Connect your infrastructure
-2. **[Discover Services](services/add-services)** - Find and import your applications  
+2. **[Discover Services](services/add-services)** - Find and import your applications
 3. **[Monitor Everything](../dashboards/overview)** - Keep your services healthy
 
 :::tip Pro Tip

--- a/opsimate-docs/docs/providers-services/providers/add-provider.md
+++ b/opsimate-docs/docs/providers-services/providers/add-provider.md
@@ -25,7 +25,7 @@ Adding a provider to OpsiMate is simple and takes just a few steps:
    Save your configuration and start adding services.
 
 <div style={{textAlign: 'center', margin: '30px 0'}}>
-  <img src="/img/myprovider-page.png" alt="My Providers Dashboard" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+   <img src="/img/myprovider-page.png" alt="Screenshot of my providers dashboard" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>My Providers page showing configured infrastructure providers and their services</p>
 </div>
 
@@ -39,9 +39,10 @@ Once your provider is added:
 
 :::info Provider Types
 You can find detailed guides for specific provider types in the other pages in this folder:
+
 - **[Server Provider](server-provider)** - SSH-based server monitoring
 - **[Kubernetes Provider](kubernetes-provider)** - K8s cluster integration
-:::
+  :::
 
 :::tip Best Practice
 Start with one provider and ensure it's working perfectly before adding more. This makes troubleshooting much easier!

--- a/opsimate-docs/docs/providers-services/providers/kubernetes-provider.md
+++ b/opsimate-docs/docs/providers-services/providers/kubernetes-provider.md
@@ -12,16 +12,16 @@ Kubernetes providers require kubeconfig file access to establish cluster monitor
 
 ### Connection Parameters
 
-| Parameter | Type | Description | Required |
-|-----------|------|-------------|----------|
-| **Kubeconfig File** | String | Kubeconfig filename for cluster access | Yes |
+| Parameter           | Type   | Description                            | Required |
+| ------------------- | ------ | -------------------------------------- | -------- |
+| **Kubeconfig File** | String | Kubeconfig filename for cluster access | Yes      |
 
 ### Kubeconfig Configuration
 
 Place your kubeconfig files in the `data/private-keys/` directory and reference only the filename:
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/kubernetes-provider-add.png" alt="Adding Kubernetes Provider" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/kubernetes-provider-add.png" alt="Screenshot showing adding a Kubernetes provider" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>Kubernetes provider configuration form</p>
 </div>
 

--- a/opsimate-docs/docs/providers-services/providers/server-provider.md
+++ b/opsimate-docs/docs/providers-services/providers/server-provider.md
@@ -13,13 +13,14 @@ A Server Provider represents a single server that hosts multiple services. This 
 ## Quick Setup
 
 ### Prerequisites
+
 - SSH access to the target server
 - SSH key authentication (recommended) or password access
 - Server running Linux, macOS, or Windows with SSH server
 
 ### Basic Configuration
 
-```yaml
+````yaml
 name: "Production Web Server"
 type: "server"
 host: "192.168.1.100"
@@ -27,10 +28,10 @@ port: 22
 
 ```yaml
 ssh_key_file: "server_key.pem"
-```
+````
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/serverprovider.png" alt="Audit Log Dashboard" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/serverprovider.png" alt="Screenshot of server provider configuration" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '5px', fontStyle: 'italic'}}>Adding a server provider to OpsiMate</p>
 </div>
 

--- a/opsimate-docs/docs/providers-services/services/container-services.md
+++ b/opsimate-docs/docs/providers-services/services/container-services.md
@@ -11,6 +11,7 @@ Monitor Docker containers running on your servers.
 **Automatic Detection**: OpsiMate checks for existing containers, and you can add them directly from the add screen.
 
 ### Process
+
 1. Click the three-dots menu
 2. Select "Add Services"
 3. Choose your server provider
@@ -18,7 +19,7 @@ Monitor Docker containers running on your servers.
 5. Choose from detected containers
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/adding-container-service.png" alt="Adding Container Service" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/adding-container-service.png" alt="Screenshot of adding a container service" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>Adding a Docker container service to OpsiMate</p>
 </div>
 
@@ -27,6 +28,7 @@ Monitor Docker containers running on your servers.
 **Docker Commands**: Controlled via SSH commands with Docker.
 
 ### Basic Operations
+
 ```bash
 # Start container
 docker start container-name

--- a/opsimate-docs/docs/providers-services/services/systemd-services.md
+++ b/opsimate-docs/docs/providers-services/services/systemd-services.md
@@ -11,6 +11,7 @@ Monitor Linux system services managed by systemd.
 **Manual Entry**: Added manually by entering the service name.
 
 ### Process
+
 1. Click the three-dots menu
 2. Select "Add Services"
 3. Choose your server provider
@@ -18,7 +19,7 @@ Monitor Linux system services managed by systemd.
 5. Enter the service name (e.g., "nginx", "postgresql")
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/systemd_service.png" alt="Systemd Service Configuration" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/systemd_service.png" alt="Screenshot of systemd service configuration" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>Adding a systemd service to OpsiMate</p>
 </div>
 
@@ -27,6 +28,7 @@ Monitor Linux system services managed by systemd.
 **SSH Commands**: Controlled via SSH commands using `service start`, `stop`, `restart`, to manage the service.
 
 ### Basic Operations
+
 ```bash
 # Start service
 sudo systemctl start service-name

--- a/opsimate-docs/docs/user-management/admin-panel.md
+++ b/opsimate-docs/docs/user-management/admin-panel.md
@@ -5,11 +5,11 @@ sidebar_position: 2
 # Admin Panel
 
 The Admin Panel allows administrators to manage users and system settings.
+
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/user-management.png" alt="User Management Interface" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/user-management.png" alt="Screenshot of user management interface" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>User management dashboard for adding and configuring team members</p>
 </div>
-
 
 ## User Management
 
@@ -27,4 +27,3 @@ The Admin Panel allows administrators to manage users and system settings.
 - **Admin**: Full system access and user management
 - **User**: Standard monitoring and configuration access
 - **Viewer**: Read-only access to dashboards and alerts
-

--- a/opsimate-docs/docs/user-management/audit-logs.md
+++ b/opsimate-docs/docs/user-management/audit-logs.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 OpsiMate maintains comprehensive audit logs for all provider-related activities and system changes.
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/auditlog.png" alt="Audit Log Dashboard" style={{width: '700px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/auditlog.png" alt="Screenshot of audit log dashboard" style={{width: '700px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>Comprehensive audit log showing all system activities and user actions</p>
 </div>
 


### PR DESCRIPTION
## Description
Add short, descriptive alt text to screenshots and explanatory images across the docs to improve accessibility and SEO.  
No image sources or styling were changed.

## Files Changed (Summary)
- Updated alt text in:
  - `dashboard`
  - `alerts`
  - `integrations`
  - `providers-services`
  - `user-management` docs

## Quick Verification
 Preview locally:
   ```bash
   cd opsimate-docs
   npm install
   npm start
   ```
 Open the changed pages to confirm images and alt text are displaying correctly.

fixes #7 