### PR TITLE
docs: replace inline image styles with css classes

### DIFF
--- a/opsimate-docs/docs/alerts/alert-management.md
+++ b/opsimate-docs/docs/alerts/alert-management.md
@@ -8,7 +8,7 @@ The Alert Management page provides a centralized view of all alerts across your 
 
 
 <div style={{textAlign: 'center', margin: '30px 0'}}>
-  <img src="/img/alertpage.png" alt="OpsiMate Alerts Page" style={{width: '700px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/alertpage.png" alt="OpsiMate Alerts Page" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>OpsiMate alerts dashboard showing real-time notifications and alert management</p>
 </div>
 

--- a/opsimate-docs/docs/dashboards/overview.md
+++ b/opsimate-docs/docs/dashboards/overview.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 The main interface for monitoring and controlling your services.
 
 <div style={{textAlign: 'center', margin: '30px 0'}}>
-  <img src="/img/dashboard-fullview.png" alt="OpsiMate Dashboard" style={{width: '800px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/dashboard-fullview.png" alt="OpsiMate Dashboard" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>OpsiMate main dashboard showing service overview and controls</p>
 </div>
 

--- a/opsimate-docs/docs/dashboards/service-menu.md
+++ b/opsimate-docs/docs/dashboards/service-menu.md
@@ -11,7 +11,7 @@ Access service-specific options and controls through the right-side menu.
 Click on any service in the dashboard to open the service-specific menu panel.
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/service-sidebar.png" alt="Service Menu Sidebar" style={{width: '400px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/service-sidebar.png" alt="Service Menu Sidebar" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>Service menu sidebar with detailed controls and information</p>
 </div>
 

--- a/opsimate-docs/docs/getting-started/deploy.md
+++ b/opsimate-docs/docs/getting-started/deploy.md
@@ -56,7 +56,7 @@ curl http://localhost:8080/health
 
 When you first access OpsiMate at `http://localhost:8080`, you'll be prompted to create your first admin user:
 
-<img src="/img/first-login.png" alt="First Login Screen" style={{width: '400px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+<img src="/img/first-login.png" alt="First Login Screen" class="doc-image" />
 
 Simply fill in your email, full name, and password to create the initial admin account. This user will have full administrative privileges to configure providers, manage services, and access all OpsiMate features.
 

--- a/opsimate-docs/docs/integrations/overview.md
+++ b/opsimate-docs/docs/integrations/overview.md
@@ -46,7 +46,7 @@ Cloud monitoring and analytics platform for infrastructure, applications, and lo
 4. Follow the setup instructions
 
 <div class="image-container">
-  <img src="/img/adding-grafana-integration.png" alt="Grafana Integration Setup" />
+  <img src="/img/adding-grafana-integration.png" alt="Grafana Integration Setup" class="doc-image" />
   <p>Setting up Grafana integration in OpsiMate</p>
 </div>
 

--- a/opsimate-docs/docs/providers-services/overview.md
+++ b/opsimate-docs/docs/providers-services/overview.md
@@ -33,7 +33,7 @@ Understanding the relationship between providers and services is key to effectiv
 </div>
 
 <div style={{textAlign: 'center', margin: '30px 0'}}>
-  <img src="/img/provider-overview.png" alt="Provider Overview Dashboard" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/provider-overview.png" alt="Provider Overview Dashboard" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>OpsiMate provider overview showing connected infrastructure</p>
 </div>
 

--- a/opsimate-docs/docs/providers-services/providers/add-provider.md
+++ b/opsimate-docs/docs/providers-services/providers/add-provider.md
@@ -25,7 +25,7 @@ Adding a provider to OpsiMate is simple and takes just a few steps:
    Save your configuration and start adding services.
 
 <div style={{textAlign: 'center', margin: '30px 0'}}>
-  <img src="/img/myprovider-page.png" alt="My Providers Dashboard" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/myprovider-page.png" alt="My Providers Dashboard" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>My Providers page showing configured infrastructure providers and their services</p>
 </div>
 

--- a/opsimate-docs/docs/providers-services/providers/kubernetes-provider.md
+++ b/opsimate-docs/docs/providers-services/providers/kubernetes-provider.md
@@ -21,7 +21,7 @@ Kubernetes providers require kubeconfig file access to establish cluster monitor
 Place your kubeconfig files in the `data/private-keys/` directory and reference only the filename:
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/kubernetes-provider-add.png" alt="Adding Kubernetes Provider" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/kubernetes-provider-add.png" alt="Adding Kubernetes Provider" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>Kubernetes provider configuration form</p>
 </div>
 

--- a/opsimate-docs/docs/providers-services/providers/server-provider.md
+++ b/opsimate-docs/docs/providers-services/providers/server-provider.md
@@ -30,7 +30,7 @@ ssh_key_file: "server_key.pem"
 ```
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/serverprovider.png" alt="Audit Log Dashboard" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/serverprovider.png" alt="Audit Log Dashboard" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '5px', fontStyle: 'italic'}}>Adding a server provider to OpsiMate</p>
 </div>
 

--- a/opsimate-docs/docs/providers-services/services/container-services.md
+++ b/opsimate-docs/docs/providers-services/services/container-services.md
@@ -18,7 +18,7 @@ Monitor Docker containers running on your servers.
 5. Choose from detected containers
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/adding-container-service.png" alt="Adding Container Service" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/adding-container-service.png" alt="Adding Container Service" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>Adding a Docker container service to OpsiMate</p>
 </div>
 

--- a/opsimate-docs/docs/providers-services/services/systemd-services.md
+++ b/opsimate-docs/docs/providers-services/services/systemd-services.md
@@ -18,7 +18,7 @@ Monitor Linux system services managed by systemd.
 5. Enter the service name (e.g., "nginx", "postgresql")
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/systemd_service.png" alt="Systemd Service Configuration" style={{width: '500px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/systemd_service.png" alt="Systemd Service Configuration" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>Adding a systemd service to OpsiMate</p>
 </div>
 

--- a/opsimate-docs/docs/user-management/admin-panel.md
+++ b/opsimate-docs/docs/user-management/admin-panel.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 The Admin Panel allows administrators to manage users and system settings.
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/user-management.png" alt="User Management Interface" style={{width: '600px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 8px rgba(0,0,0,0.1)'}} />
+  <img src="/img/user-management.png" alt="User Management Interface" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '8px', fontStyle: 'italic'}}>User management dashboard for adding and configuring team members</p>
 </div>
 

--- a/opsimate-docs/docs/user-management/audit-logs.md
+++ b/opsimate-docs/docs/user-management/audit-logs.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 OpsiMate maintains comprehensive audit logs for all provider-related activities and system changes.
 
 <div style={{textAlign: 'center', margin: '20px 0'}}>
-  <img src="/img/auditlog.png" alt="Audit Log Dashboard" style={{width: '700px', maxWidth: '100%', height: 'auto', borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.15)'}} />
+  <img src="/img/auditlog.png" alt="Audit Log Dashboard" class="doc-image" />
   <p style={{fontSize: '14px', color: '#666', marginTop: '10px', fontStyle: 'italic'}}>Comprehensive audit log showing all system activities and user actions</p>
 </div>
 

--- a/opsimate-docs/src/css/custom.css
+++ b/opsimate-docs/src/css/custom.css
@@ -47,6 +47,14 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 700;
 }
 
+/* Example CSS suggestion */
+.doc-image {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.08);
+  margin: 1rem 0;
+}
+
 /* ---------- Navbar Icons ---------- */
 .navbar-icons-container {
   display: flex;


### PR DESCRIPTION
Refactor documentation image styling by removing inline style attributes and applying a consistent css class (.doc-image) for better maintainability and design consistency across docs.

Also added the corresponding css rules in custom.css to handle the visual presentation previously defined inline.