### PR TITLE
Fix: Hide navbar mobile toggle button on desktop resolutions

### DIFF
--- a/opsimate-docs/src/css/custom.css
+++ b/opsimate-docs/src/css/custom.css
@@ -833,3 +833,11 @@ button[class*="toggle"] {
   display: flex !important;
   visibility: visible !important;
 }
+
+@media (min-width: 1025px) {
+    .navbar .navbar__toggle {
+        display: none !important;
+        visibility: hidden !important;
+        opacity: 0 !important;
+    }
+}

--- a/opsimate-docs/static/css/unused-custom.css
+++ b/opsimate-docs/static/css/unused-custom.css
@@ -1,106 +1,118 @@
 /* ──────────────────────────────────────────────
-   OpsiMate – Global Custom Styles (Blue Theme)
-   ────────────────────────────────────────────── */
+   OpsiMate – Global Custom Styles (Blue Theme)
+   ────────────────────────────────────────────── */
 
 /* ---------- Brand & Base Colors - BLUE THEME ---------- */
 :root {
-  --ifm-color-primary: #2196f3;
-  --ifm-color-primary-dark: #1976d2;
-  --ifm-color-primary-darker: #1565c0;
-  --ifm-color-primary-light: #64b5f6;
-  --ifm-color-primary-lighter: #90caf9;
+--ifm-color-primary: #2196f3;
+--ifm-color-primary-dark: #1976d2;
+--ifm-color-primary-darker: #1565c0;
+--ifm-color-primary-light: #64b5f6;
+--ifm-color-primary-lighter: #90caf9;
 }
 
 /* ---------- Navbar - BLUE THEME ---------- */
 .navbar {
-  background-color: #2196f3;
-  padding: 0.5rem 1rem;
+background-color: #2196f3;
+padding: 0.5rem 1rem;
 }
 
 .navbar__title {
-  font-weight: 700;
-  color: #fff;
+font-weight: 700;
+color: #fff;
 }
 
 .navbar__link,
 .navbar__brand {
-  color: #fff;
+color: #fff;
 }
 
 .navbar__link:hover {
-  color: #e3f2fd;
+color: #e3f2fd;
 }
 
 /* ---------- GitHub & Slack icon links ---------- */
 .navbar__icon-link {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  margin: 0 0.25rem;
-  padding: 8px;
-  border-radius: 4px;
-  transition: all 0.2s ease;
-  color: white !important;
+display: flex;
+align-items: center;
+justify-content: center;
+width: 40px;
+height: 40px;
+margin: 0 0.25rem;
+padding: 8px;
+border-radius: 4px;
+transition: all 0.2s ease;
+color: white !important;
 }
 
 .navbar__icon-link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: #e3f2fd !important;
-  text-decoration: none;
+background-color: rgba(255, 255, 255, 0.1);
+color: #e3f2fd !important;
+text-decoration: none;
 }
 
 .navbar__icon-link svg {
-  width: 24px;
-  height: 24px;
+width: 24px;
+height: 24px;
 }
 
 .navbar__items--right {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+display: flex;
+align-items: center;
+gap: 0.5rem;
 }
 
 /* ---------- Footer - BLUE THEME ---------- */
 .footer {
-  background-color: #2196f3;
-  color: #fff;
+background-color: #2196f3;
+color: #fff;
 }
 
 .footer__link-item {
-  color: #e3f2fd;
+color: #e3f2fd;
 }
 
 .footer__link-item:hover {
-  color: #fff;
+color: #fff;
 }
 
 /* ---------- Global link colors ---------- */
 a {
-  color: #2196f3;
+color: #2196f3;
 }
 
 a:hover {
-  color: #1976d2;
+color: #1976d2;
 }
 
 /* ---------- Mobile Navigation ---------- */
 @media (max-width: 1024px) {
-  .navbar__toggle {
-    display: block;
-    color: #fff;
-  }
-  
-  .navbar__items--left {
-    display: none;
-  }
-  
-  .navbar__icon-link {
-    width: 36px;
-    height: 36px;
-    padding: 6px;
-  }
+.navbar__toggle {
+display: block;
+color: #fff;
+}
+ 
+.navbar__items--left {
+display: none;
 }
 
+.navbar__icon-link {
+width: 36px;
+height: 36px;
+padding: 6px;
+}
+}
 
+/* FIX: Hide the hamburger menu icon on wide screens (desktop)
+  If the screen is 1025px or wider, explicitly hide the toggle button.
+*/
+@media (min-width: 1025px) {
+    .navbar__toggle {
+        display: none;
+    }
+    
+    /* Ensure the main navigation links are visible on desktop */
+    .navbar__items--left {
+        display: flex; /* Assuming the default desktop layout is flex */
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3110,6 +3110,12 @@
       "integrity": "sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==",
       "license": "MIT"
     },
+    "node_modules/@docsearch/js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.2.0.tgz",
+      "integrity": "sha512-KBHVPO29QiGUFJYeAqxW0oXtGf/aghNmRrIRPT4/28JAefqoCkNn/ZM/jeQ7fHjl0KNM6C+KlLVYjwyz6lNZnA==",
+      "license": "MIT"
+    },
     "node_modules/@docsearch/react": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.9.0.tgz",
@@ -17500,6 +17506,8 @@
     "opsimate-docs": {
       "version": "0.0.0",
       "dependencies": {
+        "@docsearch/css": "^4.1.0",
+        "@docsearch/js": "^4.1.0",
         "@docusaurus/core": "3.8.1",
         "@docusaurus/preset-classic": "3.8.1",
         "@mdx-js/react": "^3.0.0",
@@ -17518,6 +17526,12 @@
       "engines": {
         "node": ">=18.0"
       }
+    },
+    "opsimate-docs/node_modules/@docsearch/css": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.2.0.tgz",
+      "integrity": "sha512-65KU9Fw5fGsPPPlgIghonMcndyx1bszzrDQYLfierN+Ha29yotMHzVS94bPkZS6On9LS8dE4qmW4P/fGjtCf/g==",
+      "license": "MIT"
     }
   }
 }


### PR DESCRIPTION
 The mobile navbar toggle was visible on desktop due to aggressive global CSS overrides. This PR increases specificity in the final media query (@media (min-width: 1025px)) to ensure display: none !important; correctly hides the toggle on wide screens.