### PR TITLE
fix(docs): resolve broken links in "Creating Dashboards" page

### DIFF
--- a/opsimate-docs/docs/dashboards/creating-dashboards.md
+++ b/opsimate-docs/docs/dashboards/creating-dashboards.md
@@ -116,10 +116,11 @@ To remove a view you no longer need:
 - **Review and Refine**: Regularly update your views as your needs change
 - **Create Team-Based Views**: Design different views for different teams
 
+
 ## Next Steps
 
 After creating your custom dashboards:
 
-1. [[Set up alerts](/docs/](/monitoring/setting-up-alerts) for critical services
-2. [[Configure integrations](/docs/](/integrations/overview) to enhance your dashboards
-3. [[Share your views](/docs/](/dashboards/sharing-dashboards) with your team
+1. [Set up alerts](../alerts/adding-alerts) for critical services.
+2. [Configure integrations](../integrations/overview)to enhance your dashboards.
+3. [Share your views](../dashboards/saving-views) with your team.


### PR DESCRIPTION
###  Description
This PR fixes broken and incorrectly formatted Markdown links in the **“Creating Dashboards”** documentation page.  
The previous links in the “Next Steps” section were either incomplete or pointed to invalid `/docs/` paths, resulting in 404 errors.

---

###  Changes Made
- Updated all “Next Steps” links to use correct relative paths.  
- Replaced malformed link syntax (`[[text](/docs/](/path)`) with valid Markdown format (`[text](path)`).  
- Verified that each link now correctly navigates to the corresponding documentation page.  
- Improved overall link reliability and user navigation flow.  

---

###  Before
Links in the “Next Steps” section were broken or led to invalid URLs.

###  After
All links now point to valid pages, improving the documentation’s usability.

---

###  Testing
- Navigated through the “Next Steps” links in the local preview.  
- Confirmed that each one opens the intended page successfully.

