### PR TITLE
fix(docs): update links in configuration document page and core feature document page

### DIFF
--- a/opsimate-docs/docs/core-features.md
+++ b/opsimate-docs/docs/core-features.md
@@ -49,7 +49,7 @@ Ready to explore OpsiMate's capabilities? Start with:
 1. **[Deploy OpsiMate](getting-started/deploy)** - Set up your monitoring platform
 2. **[Add Providers](providers-services/providers/add-provider)** - Connect your infrastructure
 3. **[Configure Services](providers-services/services/add-services)** - Set up service monitoring
-4. **[Create Alerts](monitoring/setting-up-alerts)** - Get notified of issues
+4. **[Create Alerts](alerts/adding-alerts)** - Get notified of issues
 
 :::tip
 OpsiMate automatically discovers services when you add providers, making setup fast and comprehensive.

--- a/opsimate-docs/docs/getting-started/configuration.md
+++ b/opsimate-docs/docs/getting-started/configuration.md
@@ -41,9 +41,9 @@ security:
 After configuring OpsiMate:
 
 1. **Restart the container** to apply changes
-2. **Add providers** - [Learn how](adding-providers)
-3. **Set up monitoring** - [Configure alerts](../features/alerts)
-4. **Start discovering services** - [Quick start guide](quick-start)
+2. **Add providers** - [Learn how](../providers-services/providers/add-provider)
+3. **Set up monitoring** - [Configure alerts](../alerts/adding-alerts.md)
+4. **Start discovering services** - [Quick start guide](../providers-services/services/add-services)
 
 ## Support
 


### PR DESCRIPTION
This pull request updates internal documentation links in the OpsiMate docs to ensure consistency and accuracy. The most important changes are grouped below by documentation section.

**Getting Started & Configuration Documentation:**

* Updated the link for "Add providers" to point to `../providers-services/providers/add-provider` for consistency with the new documentation structure.
* Updated the link for "Set up monitoring" to reference the new alerts configuration page at `../alerts/adding-alerts.md`.
* Updated the link for "Start discovering services" to point to `../providers-services/services/add-services`.

**Core Features Documentation:**

* Updated the "Create Alerts" link to reference the new alerts documentation at `alerts/adding-alerts`.

**Related Issues:**
- https://github.com/OpsiMate/documentation/issues/25
- https://github.com/OpsiMate/documentation/issues/24