### PR TITLE
Add link to main OpsiMate website in navbar and footer

### DIFF
--- a/opsimate-docs/docusaurus.config.js
+++ b/opsimate-docs/docusaurus.config.js
@@ -45,7 +45,7 @@ module.exports = {
         { type: 'doc', docId: 'integrations/overview', position: 'left', label: 'Integrations' },
         { type: 'doc', docId: 'user-management/register-login', position: 'left', label: 'User Management' },
         { 
-          to: 'https://www.opsimate.com/', 
+          href: 'https://www.opsimate.com/', 
           label: 'Website', 
           position: 'left' 
          },
@@ -124,29 +124,7 @@ module.exports = {
             },
           ],
         },
-        {
-          title: 'Community',
-          items: [
-            {
-              html: `
-                <div class="footer-community-icons">
-                  <a href="https://github.com/OpsiMate/documentation"
-                     target="_blank" rel="noopener noreferrer"
-                     aria-label="GitHub repository"
-                     class="footer-community-icon-link">
-                    <img src="/img/github.svg" alt="GitHub" class="footer-community-icon" />
-                  </a>
-                  <a href="https://app.slack.com/client/T096DF2LNBS/C096DF2UDLG"
-                     target="_blank" rel="noopener noreferrer"
-                     aria-label="Slack community"
-                     class="footer-community-icon-link">
-                    <img src="/img/slack.svg" alt="Slack" class="footer-community-icon" />
-                  </a>
-                </div>
-              `,
-            },
-          ],
-        },
+        
         {
          
           title: 'Community',


### PR DESCRIPTION
Hi! I added the link to the main OpsiMate website as requested in issue #18.

I've added the website link in two places:
- In the navbar at the top (as a "Website" link)
- In the footer at the bottom (under a new "Resources" section)

This makes it easy for users to find the main website while reading the docs, and also helps with SEO and navigation between the main site and documentation.

Fixes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Website" link to the main navigation bar
  * Added a "Community" section in the footer with GitHub and Slack links
  * Added a "Resources" section in the footer with Main Website and Documentation links
<!-- end of auto-generated comment: release notes by coderabbit.ai -->