### PR TITLE
Style(homepage): Remove underlines and add modern hover to doc cards

### DIFF
--- a/opsimate-docs/docusaurus.config.js
+++ b/opsimate-docs/docusaurus.config.js
@@ -149,7 +149,6 @@ module.exports = {
               },
             ],
           },
-        ],
         {
           title: 'Resources',
           items: [

--- a/opsimate-docs/src/pages/index.module.css
+++ b/opsimate-docs/src/pages/index.module.css
@@ -94,6 +94,23 @@
   border-color: var(--ifm-color-primary);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(83, 109, 254, 0.15); /* subtle indigo shadow */
+  text-decoration: none;
+}
+
+.featureCard:hover .cardTitle {
+  color: var(--ifm-color-primary-dark); /* Makes title a darker blue */
+}
+
+.featureCard:hover .cardDescription {
+  color: #212121; /* Makes description text slightly darker */
+}
+
+[data-theme='dark'] .featureCard:hover .cardTitle {
+  color: var(--ifm-color-primary-light); /* Makes title a lighter blue in dark mode */
+}
+
+[data-theme='dark'] .featureCard:hover .cardDescription {
+  color: #ffffff; /* Makes description text full white in dark mode */
 }
 
 /* Card Icon */


### PR DESCRIPTION
## Description

This PR resolves the UI issue where hovering over the "Explore the Docs" cards on the homepage would show underlines on both the title and subtitle.

Following the maintainer's suggestion, this fix removes all underlines and implements a cleaner, modern hover effect (a subtle color change on the title and description) that works in both light and dark modes.

## Related Issue

Fixes #71 

## Changes Made

* Removed `text-decoration: underline` from the `.featureCard:hover` state.
* Added new hover styles in `index.module.css` to change the `color` of `.cardTitle` and `.cardDescription`.
* Added specific hover styles for `[data-theme='dark']` to ensure the effect looks correct in dark mode.

## Screenshots of New Hover Effect

Here is how the new effect looks in light and dark modes.

### Light Mode

<img width="1223" height="615" alt="image" src="https://github.com/user-attachments/assets/60612233-3295-4dbc-960c-fb7f5a130ce6" />

### Dark Mode

<img width="1223" height="615" alt="image" src="https://github.com/user-attachments/assets/12949d63-a8dd-492e-a258-b596cf6daa59" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved documentation configuration structure issue affecting navigation parsing.

* **Style**
  * Enhanced feature card hover effects with improved color transitions and dark mode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->